### PR TITLE
Feature/add line notification switch api

### DIFF
--- a/src/api/Line/functions.ts
+++ b/src/api/Line/functions.ts
@@ -14,6 +14,19 @@ const getLineNotificationStatus =
     return res.data;
   };
 
+const switchLineNotificationStatus = async (
+  is_notification: boolean
+): Promise<void> => {
+  const res = await axios.patch(
+    ENDPOINT + "/line/notifications",
+    { is_notification: is_notification },
+    {
+      withCredentials: true,
+    }
+  );
+  return res.data;
+};
+
 const checkLineBotFriend = async (): Promise<CheckLineBotFriendResponse> => {
   const res = await axios.get(ENDPOINT + "/line/check-friend", {
     withCredentials: true,
@@ -24,5 +37,6 @@ const checkLineBotFriend = async (): Promise<CheckLineBotFriendResponse> => {
 
 export const LineApi = {
   getLineNotificationStatus,
+  switchLineNotificationStatus,
   checkLineBotFriend,
 };

--- a/src/api/Line/functions.ts
+++ b/src/api/Line/functions.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+import { GetLineNotificationStatusResponse } from "./types";
+
+const ENDPOINT: string = import.meta.env.VITE_API_URL + "/api";
+
+const getLineNotificationStatus =
+  async (): Promise<GetLineNotificationStatusResponse> => {
+    const res = await axios.get(ENDPOINT + "/line/notifications", {
+      withCredentials: true,
+    });
+    return res.data;
+  };
+
+export const LineApi = {
+  getLineNotificationStatus,
+};

--- a/src/api/Line/functions.ts
+++ b/src/api/Line/functions.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
-import { GetLineNotificationStatusResponse } from "./types";
+import {
+  CheckLineBotFriendResponse,
+  GetLineNotificationStatusResponse,
+} from "./types";
 
 const ENDPOINT: string = import.meta.env.VITE_API_URL + "/api";
 
@@ -11,6 +14,15 @@ const getLineNotificationStatus =
     return res.data;
   };
 
+const checkLineBotFriend = async (): Promise<CheckLineBotFriendResponse> => {
+  const res = await axios.get(ENDPOINT + "/line/check-friend", {
+    withCredentials: true,
+  });
+
+  return res.data;
+};
+
 export const LineApi = {
   getLineNotificationStatus,
+  checkLineBotFriend,
 };

--- a/src/api/Line/hooks.ts
+++ b/src/api/Line/hooks.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { LineApi } from "./functions";
+
+export const useGetLineNotificationStatus = () => {
+  return useQuery({
+    queryKey: ["users", "get-line-notification-status"],
+    queryFn: LineApi.getLineNotificationStatus,
+  });
+};

--- a/src/api/Line/hooks.ts
+++ b/src/api/Line/hooks.ts
@@ -1,16 +1,28 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { LineApi } from "./functions";
 
 export const useGetLineNotificationStatus = () => {
   return useQuery({
-    queryKey: ["users", "get-line-notification-status"],
+    queryKey: ["get-line-notification-status"],
     queryFn: LineApi.getLineNotificationStatus,
+  });
+};
+
+export const useSwitchLineNotificationStatus = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: LineApi.switchLineNotificationStatus,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["get-line-notification-status"],
+      });
+    },
   });
 };
 
 export const useCheckLineBotFriend = () => {
   return useQuery({
-    queryKey: ["users", "check-line-bot-friend"],
+    queryKey: ["check-line-bot-friend"],
     queryFn: LineApi.checkLineBotFriend,
   });
 };

--- a/src/api/Line/hooks.ts
+++ b/src/api/Line/hooks.ts
@@ -7,3 +7,10 @@ export const useGetLineNotificationStatus = () => {
     queryFn: LineApi.getLineNotificationStatus,
   });
 };
+
+export const useCheckLineBotFriend = () => {
+  return useQuery({
+    queryKey: ["users", "check-line-bot-friend"],
+    queryFn: LineApi.checkLineBotFriend,
+  });
+};

--- a/src/api/Line/types.ts
+++ b/src/api/Line/types.ts
@@ -1,3 +1,7 @@
 export type GetLineNotificationStatusResponse = {
   is_notification: boolean;
 };
+
+export type CheckLineBotFriendResponse = {
+  friend_flag: boolean;
+};

--- a/src/api/Line/types.ts
+++ b/src/api/Line/types.ts
@@ -1,0 +1,3 @@
+export type GetLineNotificationStatusResponse = {
+  is_notification: boolean;
+};

--- a/src/api/User/functions.ts
+++ b/src/api/User/functions.ts
@@ -3,7 +3,6 @@ import {
   CheckLineBotFriendResponse,
   CheckLoginedResponse,
   CreateLineAuthUrlResponse,
-  GetLineNotificationStatusResponse,
   LoginRequest,
   RegistRequest,
 } from "./type";
@@ -46,21 +45,12 @@ const checkLineBotFriend = async (): Promise<CheckLineBotFriendResponse> => {
   return res.data;
 };
 
-const getLineNotificationStatus =
-  async (): Promise<GetLineNotificationStatusResponse> => {
-    const res = await axios.get(ENDPOINT + "/api/line/notifications", {
-      withCredentials: true,
-    });
-    return res.data;
-  };
-
 const UserApi = {
   regist,
   login,
   checkLogined,
   createLineAuthUrl,
   checkLineBotFriend,
-  getLineNotificationStatus,
 };
 
 export default UserApi;

--- a/src/api/User/functions.ts
+++ b/src/api/User/functions.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosResponse } from "axios";
 import {
-  CheckLineBotFriendResponse,
   CheckLoginedResponse,
   CreateLineAuthUrlResponse,
   LoginRequest,
@@ -37,20 +36,11 @@ const createLineAuthUrl = async (): Promise<CreateLineAuthUrlResponse> => {
   return res.data;
 };
 
-const checkLineBotFriend = async (): Promise<CheckLineBotFriendResponse> => {
-  const res = await axios.get(ENDPOINT + "/api/line/check-friend", {
-    withCredentials: true,
-  });
-
-  return res.data;
-};
-
 const UserApi = {
   regist,
   login,
   checkLogined,
   createLineAuthUrl,
-  checkLineBotFriend,
 };
 
 export default UserApi;

--- a/src/api/User/functions.ts
+++ b/src/api/User/functions.ts
@@ -3,6 +3,7 @@ import {
   CheckLineBotFriendResponse,
   CheckLoginedResponse,
   CreateLineAuthUrlResponse,
+  GetLineNotificationStatusResponse,
   LoginRequest,
   RegistRequest,
 } from "./type";
@@ -45,12 +46,21 @@ const checkLineBotFriend = async (): Promise<CheckLineBotFriendResponse> => {
   return res.data;
 };
 
+const getLineNotificationStatus =
+  async (): Promise<GetLineNotificationStatusResponse> => {
+    const res = await axios.get(ENDPOINT + "/api/line/notifications", {
+      withCredentials: true,
+    });
+    return res.data;
+  };
+
 const UserApi = {
   regist,
   login,
   checkLogined,
   createLineAuthUrl,
   checkLineBotFriend,
+  getLineNotificationStatus,
 };
 
 export default UserApi;

--- a/src/api/User/hooks.ts
+++ b/src/api/User/hooks.ts
@@ -61,10 +61,3 @@ export const useCheckLineBotFriend = () => {
     queryFn: UserApi.checkLineBotFriend,
   });
 };
-
-export const useGetLineNotificationStatus = () => {
-  return useQuery({
-    queryKey: ["users", "get-line-notification-status"],
-    queryFn: UserApi.getLineNotificationStatus,
-  });
-};

--- a/src/api/User/hooks.ts
+++ b/src/api/User/hooks.ts
@@ -61,3 +61,10 @@ export const useCheckLineBotFriend = () => {
     queryFn: UserApi.checkLineBotFriend,
   });
 };
+
+export const useGetLineNotificationStatus = () => {
+  return useQuery({
+    queryKey: ["users", "get-line-notification-status"],
+    queryFn: UserApi.getLineNotificationStatus,
+  });
+};

--- a/src/api/User/hooks.ts
+++ b/src/api/User/hooks.ts
@@ -54,10 +54,3 @@ export const useCheckLogined = () => {
     queryFn: UserApi.checkLogined,
   });
 };
-
-export const useCheckLineBotFriend = () => {
-  return useQuery({
-    queryKey: ["users", "check-line-bot-friend"],
-    queryFn: UserApi.checkLineBotFriend,
-  });
-};

--- a/src/api/User/type.ts
+++ b/src/api/User/type.ts
@@ -26,7 +26,3 @@ export type CreateLineAuthUrlResponse = {
 export type CheckLineBotFriendResponse = {
   friend_flag: boolean;
 };
-
-export type GetLineNotificationStatusResponse = {
-  is_notification: boolean;
-};

--- a/src/api/User/type.ts
+++ b/src/api/User/type.ts
@@ -22,7 +22,3 @@ export type CheckLoginedResponse = {
 export type CreateLineAuthUrlResponse = {
   url: string;
 };
-
-export type CheckLineBotFriendResponse = {
-  friend_flag: boolean;
-};

--- a/src/api/User/type.ts
+++ b/src/api/User/type.ts
@@ -26,3 +26,7 @@ export type CreateLineAuthUrlResponse = {
 export type CheckLineBotFriendResponse = {
   friend_flag: boolean;
 };
+
+export type GetLineNotificationStatusResponse = {
+  is_notification: boolean;
+};

--- a/src/pages/Setting/SettingPageViewModel.ts
+++ b/src/pages/Setting/SettingPageViewModel.ts
@@ -1,11 +1,21 @@
-import { useCheckLineBotFriend } from "../../api/Line/hooks";
+import {
+  useCheckLineBotFriend,
+  useGetLineNotificationStatus,
+} from "../../api/Line/hooks";
 
 const useSettingPageViewModel = () => {
-  const { data, isPending } = useCheckLineBotFriend();
+  const { data: lineBotFriend, isPending: isPendingForcheckLineBotFriend } =
+    useCheckLineBotFriend();
+  const {
+    data: lineNotificationStatus,
+    isPending: isPendingForLineNotificationStatus,
+  } = useGetLineNotificationStatus();
 
   return {
-    isLineBotFriend: data?.friend_flag,
-    isPending,
+    isLineBotFriend: lineBotFriend?.friend_flag,
+    isPendingForcheckLineBotFriend,
+    isPendingForLineNotificationStatus,
+    isNotificationEnabled: lineNotificationStatus?.is_notification,
   };
 };
 

--- a/src/pages/Setting/SettingPageViewModel.ts
+++ b/src/pages/Setting/SettingPageViewModel.ts
@@ -1,4 +1,4 @@
-import { useCheckLineBotFriend } from "../../api/User/hooks";
+import { useCheckLineBotFriend } from "../../api/Line/hooks";
 
 const useSettingPageViewModel = () => {
   const { data, isPending } = useCheckLineBotFriend();

--- a/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItem.tsx
+++ b/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItem.tsx
@@ -1,25 +1,16 @@
-import { ClipLoader } from "react-spinners";
 import ToggleSettingItem from "../ToggleSettingltem/ToggleSettingItem";
 import LineNotificationSettingItemViewModel from "./LineNotificationSettingItemViewModel";
 
 const LineNotificationSettingItem = ({
   isLineBotFriend,
+  isNotificationEnabled,
 }: {
   isLineBotFriend: boolean;
+  isNotificationEnabled: boolean;
 }) => {
-  const {
-    isPendingForGetLineNotificationStatus,
-    isNotificationEnabled,
-    onChangeToggle,
-    description,
-  } = LineNotificationSettingItemViewModel(isLineBotFriend);
+  const { onChangeToggle, description } =
+    LineNotificationSettingItemViewModel(isLineBotFriend);
 
-  if (
-    isNotificationEnabled === undefined ||
-    isPendingForGetLineNotificationStatus
-  ) {
-    return <ClipLoader size={25} color="rgba(255, 255, 255, 0.9)" />;
-  }
   return (
     <ToggleSettingItem
       title="LINE通知"

--- a/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItem.tsx
+++ b/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItem.tsx
@@ -1,3 +1,4 @@
+import { ClipLoader } from "react-spinners";
 import ToggleSettingItem from "../ToggleSettingltem/ToggleSettingItem";
 import LineNotificationSettingItemViewModel from "./LineNotificationSettingItemViewModel";
 
@@ -6,9 +7,19 @@ const LineNotificationSettingItem = ({
 }: {
   isLineBotFriend: boolean;
 }) => {
-  const { isNotificationEnabled, onChangeToggle, description } =
-    LineNotificationSettingItemViewModel(isLineBotFriend);
+  const {
+    isPendingForGetLineNotificationStatus,
+    isNotificationEnabled,
+    onChangeToggle,
+    description,
+  } = LineNotificationSettingItemViewModel(isLineBotFriend);
 
+  if (
+    isNotificationEnabled === undefined ||
+    isPendingForGetLineNotificationStatus
+  ) {
+    return <ClipLoader size={25} color="rgba(255, 255, 255, 0.9)" />;
+  }
   return (
     <ToggleSettingItem
       title="LINE通知"

--- a/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
+++ b/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
@@ -1,12 +1,24 @@
+import { useSwitchLineNotificationStatus } from "../../../../api/Line/hooks";
+import { showSuccessToast } from "../../../../util/CustomToast";
+
 const LineNotificationSettingItemViewModel = (isLineBotFriend: boolean) => {
-  // 2つ目: LINE通知のON/OFFの状態を取得するAPI
-  // 3つ目: LINE通知のON/OFFの状態を変更するAPI
+  const { mutate } = useSwitchLineNotificationStatus();
+  const onChangeToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // e.target.checkedをLINE通知のON/OFFに反映させるAPIを呼び出す
+    mutate(e.target.checked, {
+      onSuccess: () => {
+        if (e.target.checked) {
+          showSuccessToast("LINE通知をOFFにしました✅");
+        } else {
+          showSuccessToast("LINE通知をONにしました✅");
+        }
+      },
+    });
+  };
+
   return {
     // LINE通知のON/OFFの状態を取得するAPIを呼び出す
-    onChangeToggle: (e: React.ChangeEvent<HTMLInputElement>) => {
-      console.log(e.target.checked);
-      // e.target.checkedをLINE通知のON/OFFに反映させるAPIを呼び出す
-    },
+    onChangeToggle,
     description: isLineBotFriend
       ? "LINEの通知機能のON/OFFできます"
       : "LINEの連携が完了すると、設定できます",

--- a/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
+++ b/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
@@ -1,14 +1,8 @@
-import { useGetLineNotificationStatus } from "../../../../api/Line/hooks";
-
 const LineNotificationSettingItemViewModel = (isLineBotFriend: boolean) => {
   // 2つ目: LINE通知のON/OFFの状態を取得するAPI
   // 3つ目: LINE通知のON/OFFの状態を変更するAPI
-  const { data, isPending } = useGetLineNotificationStatus();
-
   return {
-    isPendingForGetLineNotificationStatus: isPending,
     // LINE通知のON/OFFの状態を取得するAPIを呼び出す
-    isNotificationEnabled: data?.is_notification,
     onChangeToggle: (e: React.ChangeEvent<HTMLInputElement>) => {
       console.log(e.target.checked);
       // e.target.checkedをLINE通知のON/OFFに反映させるAPIを呼び出す

--- a/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
+++ b/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
@@ -1,4 +1,4 @@
-import { useGetLineNotificationStatus } from "../../../../api/User/hooks";
+import { useGetLineNotificationStatus } from "../../../../api/Line/hooks";
 
 const LineNotificationSettingItemViewModel = (isLineBotFriend: boolean) => {
   // 2つ目: LINE通知のON/OFFの状態を取得するAPI

--- a/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
+++ b/src/pages/Setting/components/LineNotificationSettingItem/LineNotificationSettingItemViewModel.ts
@@ -1,9 +1,14 @@
+import { useGetLineNotificationStatus } from "../../../../api/User/hooks";
+
 const LineNotificationSettingItemViewModel = (isLineBotFriend: boolean) => {
   // 2つ目: LINE通知のON/OFFの状態を取得するAPI
   // 3つ目: LINE通知のON/OFFの状態を変更するAPI
+  const { data, isPending } = useGetLineNotificationStatus();
+
   return {
+    isPendingForGetLineNotificationStatus: isPending,
     // LINE通知のON/OFFの状態を取得するAPIを呼び出す
-    isNotificationEnabled: true,
+    isNotificationEnabled: data?.is_notification,
     onChangeToggle: (e: React.ChangeEvent<HTMLInputElement>) => {
       console.log(e.target.checked);
       // e.target.checkedをLINE通知のON/OFFに反映させるAPIを呼び出す

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -7,23 +7,34 @@ import useSettingPageViewModel from "./SettingPageViewModel";
 import { ClipLoader } from "react-spinners";
 
 const SettingPage = () => {
-  const { isLineBotFriend, isPending } = useSettingPageViewModel();
-  console.log(isLineBotFriend);
+  const {
+    isLineBotFriend,
+    isPendingForcheckLineBotFriend,
+    isNotificationEnabled,
+    isPendingForLineNotificationStatus,
+  } = useSettingPageViewModel();
+
   return (
     <div className={styles.settings_container}>
       <SettingHeader />
       <div className={styles.settings_section}>
         <h2 className={styles.section_title}>通知の設定</h2>
         <WebNotificationSettingItem />
-        {isPending || isLineBotFriend === undefined ? (
+        {isPendingForcheckLineBotFriend ||
+        isLineBotFriend === undefined ||
+        isPendingForLineNotificationStatus ||
+        isNotificationEnabled === undefined ? (
           <ClipLoader size={25} color="rgba(255, 255, 255, 0.9)" />
         ) : (
-          <LineNotificationSettingItem isLineBotFriend={isLineBotFriend} />
+          <LineNotificationSettingItem
+            isLineBotFriend={isLineBotFriend}
+            isNotificationEnabled={isNotificationEnabled}
+          />
         )}
       </div>
       <div className={styles.settings_section}>
         <h2 className={styles.section_title}>LINE連携</h2>
-        {isPending || isLineBotFriend === undefined ? (
+        {isPendingForcheckLineBotFriend || isLineBotFriend === undefined ? (
           <ClipLoader size={25} color="rgba(255, 255, 255, 0.9)" />
         ) : (
           <LineBotSettingItem isLineBotFriend={isLineBotFriend} />


### PR DESCRIPTION
状態からのローディングのロジックなどは、共通化したい。ロジックの置き場所がどこであるべきか改めて考える

useQueryの方が、useSuspenseQueryより柔軟にPending中の処理をかける。useSuspenseQuery()を使う場合だと、ローディングコンポーネントを表示したい場所がAPI呼び出しの上位に置いていないといけないのが辛い。