### PR TITLE
modify loading

### DIFF
--- a/src/api/FCM/hooks.ts
+++ b/src/api/FCM/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { FCMApi } from "./functions";
 import { SaveFCMTokenRequest } from "./types";
 import { commonFCMApiErrorHandler } from "./errorHandlers";
@@ -21,7 +21,7 @@ export const useInvalidateLatestFCMToken = () => {
 };
 
 export const useCheckExistValidFCMToken = () => {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: ["check-exist-valid-fcm-token"],
     queryFn: async () => {
       const data = await FCMApi.checkExistValidFCMToken();

--- a/src/api/Todo/hooks.ts
+++ b/src/api/Todo/hooks.ts
@@ -1,8 +1,8 @@
 import {
   QueryClient,
   useMutation,
+  useQuery,
   useQueryClient,
-  useSuspenseQuery,
 } from "@tanstack/react-query";
 import TodoApi from "./functions";
 import { UpdateTodosRequest } from "./types";
@@ -27,8 +27,7 @@ export type useGetTodosResponse = {
 };
 
 export const useGetTodos = () => {
-  // 結局、updateをキャッシュ更新して、cancelQueriesを実行しても、invalidateは上書きされて、処理は完了している？？？だから、statusがdoneに書き換わっている？
-  return useSuspenseQuery({
+  const { data, isPending } = useQuery({
     queryKey: ["todos"],
     queryFn: async (): Promise<useGetTodosResponse> => {
       const data = await TodoApi.getTodos();
@@ -53,6 +52,14 @@ export const useGetTodos = () => {
       return { imcompletedTodosWithStatus, completedTodosWithStatus };
     },
   });
+
+  return {
+    data: data || {
+      imcompletedTodosWithStatus: [],
+      completedTodosWithStatus: [],
+    },
+    isPending,
+  };
 };
 
 export const useCreateTodo = () => {

--- a/src/pages/Setting/components/ToggleSettingltem/ToggleSettingItem.tsx
+++ b/src/pages/Setting/components/ToggleSettingltem/ToggleSettingItem.tsx
@@ -1,3 +1,4 @@
+import { ClipLoader } from "react-spinners";
 import ToggleButton from "../../../../components/ToggleButton";
 import styles from "./ToggleSettingItem.module.css";
 
@@ -7,6 +8,7 @@ type Props = {
   checked: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   disabled?: boolean;
+  isPendingForToggleButton?: boolean;
 };
 
 const ToggleSettingItem = ({
@@ -15,6 +17,7 @@ const ToggleSettingItem = ({
   checked,
   onChange,
   disabled = false,
+  isPendingForToggleButton = false,
 }: Props) => {
   return (
     <div className={styles.toggle_container}>
@@ -22,7 +25,15 @@ const ToggleSettingItem = ({
         <p className={styles.toggle_label}>{title}</p>
         <p className={styles.toggle_description}>{description}</p>
       </div>
-      <ToggleButton checked={checked} onChange={onChange} disabled={disabled} />
+      {isPendingForToggleButton ? (
+        <ClipLoader size={25} color="rgba(255, 255, 255, 0.9)" />
+      ) : (
+        <ToggleButton
+          checked={checked}
+          onChange={onChange}
+          disabled={disabled}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/Setting/components/WebNotificationSettingItem/WebNotificationSettingItem.tsx
+++ b/src/pages/Setting/components/WebNotificationSettingItem/WebNotificationSettingItem.tsx
@@ -10,15 +10,16 @@ const WebNotificationSettingItem = () => {
   } = WebNotificationSettingItemViewModel();
   // isNotificationEnabledの状態が確定していない時はトグルを表示しない
   // →トグルが表示された後に、操作もしていないのに変化したらユーザに混乱を与えるため
-  if (isNotificationEnabled === null) return <p>...loading</p>;
+  const isPending = isNotificationEnabled === null;
 
   return (
     <ToggleSettingItem
       title="ブラウザ通知"
       description={description}
-      checked={isNotificationEnabled}
+      checked={isNotificationEnabled === null ? false : isNotificationEnabled}
       onChange={onChangeToggle}
       disabled={isDisabledToggle}
+      isPendingForToggleButton={isPending}
     />
   );
 };

--- a/src/pages/Setting/useFCMNotification.ts
+++ b/src/pages/Setting/useFCMNotification.ts
@@ -10,7 +10,10 @@ import {
 } from "../../api/FCM/hooks";
 
 const useFCMNotification = () => {
-  const { data: isExistValidFCMToken } = useCheckExistValidFCMToken();
+  const {
+    data: isExistValidFCMToken,
+    isPending: isPendingForCheckIsExistValidFCMToken,
+  } = useCheckExistValidFCMToken();
   const [isNotificationEnabled, setIsNotificationEnabled] = useState<
     boolean | null
   >(null);
@@ -26,15 +29,20 @@ const useFCMNotification = () => {
         setIsNotificationEnabled(false);
         return;
       }
-
+      setIsDeniedPermission(Notification.permission === "denied");
+      if (
+        isPendingForCheckIsExistValidFCMToken ||
+        isExistValidFCMToken === undefined
+      ) {
+        return;
+      }
       setIsNotificationEnabled(
         Notification.permission === "granted" && isExistValidFCMToken
       );
-      setIsDeniedPermission(Notification.permission === "denied");
     };
 
     initialize();
-  }, [isExistValidFCMToken]);
+  }, [isExistValidFCMToken, isPendingForCheckIsExistValidFCMToken]);
 
   const { mutate: saveFCMTokenMutate } = useSaveFCMToken();
   const { mutate: invalidateLatestFCMTokenMutate } =

--- a/src/pages/Todo/index.tsx
+++ b/src/pages/Todo/index.tsx
@@ -10,9 +10,11 @@ import {
 } from "@dnd-kit/sortable";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import Header from "./components/Header/Header";
+import { ClipLoader } from "react-spinners";
 
 const TodoPage = () => {
   const {
+    isPendingForGetTodos,
     imcompletedTodos,
     completedTodos,
     createTodo,
@@ -36,29 +38,33 @@ const TodoPage = () => {
           isPendingForCreateTodo={isPendingForCreateTodo}
           submit={createTodo}
         />
-        <>
-          <DndContext
-            sensors={sensors}
-            modifiers={[restrictToVerticalAxis]}
-            collisionDetection={closestCenter} // ソート可能なリストはデフォルトのRectangle intersectionより判定が甘いアルゴリズムにする
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={imcompletedTodos}
-              strategy={verticalListSortingStrategy}
+        {isPendingForGetTodos ? (
+          <ClipLoader size={25} color="rgba(255, 255, 255, 0.9)" />
+        ) : (
+          <>
+            <DndContext
+              sensors={sensors}
+              modifiers={[restrictToVerticalAxis]}
+              collisionDetection={closestCenter} // ソート可能なリストはデフォルトのRectangle intersectionより判定が甘いアルゴリズムにする
+              onDragEnd={handleDragEnd}
             >
-              <ImcompletedTodos
-                todos={imcompletedTodos}
-                creatingTodoForPending={creatingTodoForPending}
-                isPendingForCreateTodo={isPendingForCreateTodo}
-                updateTodo={updateTodo}
-                updateTodoDetail={updateTodoDetail}
-                deleteTodo={deleteTodo}
-              />
-            </SortableContext>
-          </DndContext>
-          <CompletedTodos todos={completedTodos} updateTodo={updateTodo} />
-        </>
+              <SortableContext
+                items={imcompletedTodos}
+                strategy={verticalListSortingStrategy}
+              >
+                <ImcompletedTodos
+                  todos={imcompletedTodos}
+                  creatingTodoForPending={creatingTodoForPending}
+                  isPendingForCreateTodo={isPendingForCreateTodo}
+                  updateTodo={updateTodo}
+                  updateTodoDetail={updateTodoDetail}
+                  deleteTodo={deleteTodo}
+                />
+              </SortableContext>
+            </DndContext>
+            <CompletedTodos todos={completedTodos} updateTodo={updateTodo} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Todo/useTodoViewModel.ts
+++ b/src/pages/Todo/useTodoViewModel.ts
@@ -21,7 +21,7 @@ import { showSuccessToast } from "../../util/CustomToast";
 
 const useTodoViewModel = () => {
   // TODOの取得と定義
-  const { data: todos } = useGetTodos();
+  const { data: todos, isPending: isPendingForGetTodos } = useGetTodos();
   const imcompletedTodos = todos.imcompletedTodosWithStatus;
   const completedTodos = todos.completedTodosWithStatus;
 
@@ -98,6 +98,7 @@ const useTodoViewModel = () => {
   };
 
   return {
+    isPendingForGetTodos,
     imcompletedTodos,
     completedTodos,
     createTodo,


### PR DESCRIPTION
LINE関連の設定もローディングをトグルの部分だけとかにしたかったが、説明文の切り替えもAPIフェッチに依存しているため、説明文もローディング、トグルもローディングだと変なので、設定項目ごとローディングにするようにしている。
<img width="425" alt="image" src="https://github.com/user-attachments/assets/09ecf098-1d9f-4a60-9b8a-2dd2ea91e021" />

設定項目のラベルと説明文、右側のアクション（トグルやログインボタンなど）の位置関係を変えれば、ラベルは常に表示で、説明文やアクションの部分をローディングにするとかできそう？
デザイン的に見てみないと何とも言えない！
